### PR TITLE
Check allocation is succeeded in `alloc_pages`

### DIFF
--- a/os/src/memory.rs
+++ b/os/src/memory.rs
@@ -82,6 +82,9 @@ impl ContiguousPhysicalMemoryPages {
         let layout = Layout::from_size_align(PAGE_SIZE * num_pages, PAGE_SIZE)
             .or(Err(Error::Failed("Invalid layout")))?;
         let phys_addr = ALLOCATOR.alloc_with_options(layout);
+        if phys_addr.is_null() {
+            return Err(Error::Failed("Failed to allocate pages"));
+        }
         Ok(Self { layout, phys_addr })
     }
     pub fn fill_with_bytes(&mut self, value: u8) {


### PR DESCRIPTION
I've came up with code while working on #24
we can detect allocation error. 

It's very weird if `alloc_pages` doesn't care about allocation error while  `alloc_pages`'s return type is Result<Self> 