### PR TITLE
A bug of BIT_CS_READABLE  gdt.rs

### DIFF
--- a/os/src/x86_64/gdt.rs
+++ b/os/src/x86_64/gdt.rs
@@ -15,7 +15,7 @@ pub const BIT_TYPE_CODE: u64 = 0b11u64 << 43;
 
 pub const BIT_PRESENT: u64 = 1u64 << 47;
 pub const BIT_CS_LONG_MODE: u64 = 1u64 << 53;
-pub const BIT_CS_READABLE: u64 = 1u64 << 53;
+pub const BIT_CS_READABLE: u64 = 1u64 << 41;
 pub const BIT_DS_WRITABLE: u64 = 1u64 << 41;
 pub const BIT_DPL0: u64 = 0u64 << 45;
 pub const BIT_DPL3: u64 = 3u64 << 45;


### PR DESCRIPTION
Thank you for the nice OS book!
In your book, I found a bug at the book branch, and also checked this branch. 

reference: 
https://wiki.osdev.org/Global_Descriptor_Table