### PR TITLE
`locate_graphic_protocol`のライフタイムをOS本の説明にあわせた

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Wasabi OS continuous integration
 on: [push]
 jobs:
   build-and-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: hikalium/wasabi-builder:latest
     steps:
       - name: Dump metadata

--- a/os/src/efi.rs
+++ b/os/src/efi.rs
@@ -402,9 +402,9 @@ pub fn alloc_byte_slice<'a>(
     Ok(unsafe { core::slice::from_raw_parts_mut(pages, size) })
 }
 
-pub fn locate_graphic_protocol<'a>(
+pub fn locate_graphic_protocol(
     efi_system_table: Pin<&EfiSystemTable>,
-) -> Result<&'a EfiGraphicsOutputProtocol<'a>> {
+) -> Result<&EfiGraphicsOutputProtocol<'_>> {
     let mut graphic_output_protocol: *mut EfiGraphicsOutputProtocol =
         null_mut::<EfiGraphicsOutputProtocol>();
     let status = (efi_system_table.as_ref().boot_services.locate_protocol)(


### PR DESCRIPTION
### 概要

- [［作って学ぶ］OSのしくみⅠ](https://gihyo.jp/book/2025/978-4-297-14859-1)の64ページで、`locate_graphic_protocol`のライフタイムについて下記のように解説されている
    - > 実際にはこの関数のシグネチャ（型定義）より、このポインタのライフタイムは、引数として渡している`EfiSystemTable` の参照が持つライフタイムと同じになるとコンパイラによって推論されます[^注34]。
   > [^注34]: https://doc.rust-lang.org/reference/lifetime-elision.html
   - <img src="https://github.com/user-attachments/assets/89424d7b-d304-4c52-a2bd-24a1cae6586a" width="30%"/>
- 注34にある仕様書ではないが、[The Rust Programming Language](https://doc.rust-lang.org/book/ch10-03-lifetime-syntax.html#lifetime-elision)の説明をまとめるとこの 👇 ようになると考えられる
    1. 引数にある参照は別々のライフタイムになるので、`&EfiSystemTable`には`'a`とは別のライフタイムパラメーターがわりあてられる
    2. 入力にライフタイムパラメーターがある場合はそれが返り値にも割り当てされるが、今回は`EfiGraphicsOutputProtocol`のライフタイムは明示的にライフタイムパラメーター`'a`が割り当てされていた
- したがってこれまでの`locate_graphic_protocol`は下記のように引数と返り値で異なるライフタイムパラメーターが割り当てされていたと考えられる
    ```rust
    pub fn locate_graphic_protocol<'a, 'b>(
        efi_system_table: Pin<&'b EfiSystemTable>,
    ) -> Result<&'a EfiGraphicsOutputProtocol<'a>> {
    ```
    - ☝️ このコードは`'a == 'b`なライフタイムパラメーターを取ることもできるし、または`'a != 'b`なライフタイムパラメーターを取ることもできる、より制約が少ない汎用的な関数となっていた
    - Playgroundででやってみても、引数と返り値のライフタイムが異っても型チェックを通過する
         - https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=eb74f4416e82709faf707e40d8eaf660
- 下記のコミットまでは引数`efi_system_table`も返り値も同じライフタイムパラメーター`'a`が用いられていたので、リファクタリングの際に意図せず異なるライフタイムパラメーターになってしまったと判断し、本を正としたライフタイムパラメーターに修正した
    - https://github.com/hikalium/wasabi/commit/9880bafcf47a58aa91c0afd02b989606e48b2865#diff-d5574fd4576a39d0ac0a2e0da032689b971a4a3ffcac06ba2f4751aeced1be48R727-R728
    - Playgroundでもこちらは型が通らなくなる
        - https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=04753ef66bf1468b62bff947de740cf0
